### PR TITLE
feat: simplify video preset initialization

### DIFF
--- a/console/run.go
+++ b/console/run.go
@@ -1,0 +1,37 @@
+package console
+
+import (
+	"github.com/clktmr/n64/drivers/display"
+)
+
+// Gamelooper represents a game instance that can be updated and drawn.
+type Gamelooper interface {
+	// Update is called every frame to update game logic.
+	// Return an error to exit the game loop, nil to continue.
+	Update() error
+
+	// Draw is called every frame to render the game.
+	// The screen is already initialized and ready for drawing.
+	Draw(screen *display.Screen)
+}
+
+// Run starts the game loop with default video settings (NTSC 320x240, no interlacing).
+// It will initialize the display, then repeatedly call Update() and Draw().
+func Run(g Gamelooper) error {
+	// Initialize display with default settings
+	qualityPreset := display.LowRes // TODO: make this configurable
+	screen := display.Init(qualityPreset)
+
+	// Main game loop
+	for {
+		// Update game logic
+		if err := g.Update(); err != nil {
+			return err
+		}
+
+		// Draw game
+		screen.BeginDrawing()
+		g.Draw(screen)
+		screen.EndDrawing()
+	}
+}

--- a/drivers/display/screen.go
+++ b/drivers/display/screen.go
@@ -1,0 +1,86 @@
+package display
+
+import (
+	"image"
+	"image/color"
+	"image/draw"
+
+	n64draw "github.com/clktmr/n64/drivers/draw"
+	"github.com/clktmr/n64/machine"
+	"github.com/clktmr/n64/rcp/video"
+)
+
+// VideoPreset represents a predefined video configuration
+type VideoPreset int
+
+const (
+	// LowRes is the most common setup: 320x240 without interlacing
+	LowRes VideoPreset = iota
+	// HighRes is 640x480 with interlacing
+	HighRes
+)
+
+// Screen represents the display surface that can be drawn to.
+type Screen struct {
+	renderer *n64draw.Rdp
+}
+
+// BeginDrawing prepares for a new frame by swapping the framebuffer.
+func (s *Screen) BeginDrawing() {
+	fb := currentScreen.Display.Swap()
+	s.renderer.SetFramebuffer(fb)
+}
+
+// EndDrawing finalizes the frame by flushing the renderer.
+func (s *Screen) EndDrawing() {
+	s.renderer.Flush()
+}
+
+// ClearBackground clears the screen with the specified color.
+func (s *Screen) ClearBackground(c color.Color) {
+	s.renderer.Draw(s.renderer.Bounds(), &image.Uniform{c}, image.Point{}, draw.Src)
+}
+
+// screen holds all the display-related objects and state.
+type screen struct {
+	Display  *Display
+	Renderer *n64draw.Rdp
+}
+
+var currentScreen *screen
+
+// getPresetConfig returns the configuration for a given preset
+func getPresetConfig(preset VideoPreset) (resolution image.Point, colorDepth video.ColorDepth, mode machine.VideoType, interlaced bool) {
+	switch preset {
+	case LowRes:
+		return image.Point{X: 320, Y: 240}, video.ColorDepth(video.BPP16), machine.VideoNTSC, false
+	case HighRes:
+		return image.Point{X: 640, Y: 480}, video.ColorDepth(video.BPP32), machine.VideoNTSC, true
+	default:
+		return image.Point{X: 320, Y: 240}, video.ColorDepth(video.BPP16), machine.VideoNTSC, false
+	}
+}
+
+// Init initializes display with the specified video preset.
+// It sets up the framebuffer and renderer for drawing.
+func Init(preset VideoPreset) *Screen {
+	resolution, colorDepth, mode, interlaced := getPresetConfig(preset)
+
+	// Set the video mode and setup
+	machine.Video = mode
+	video.Setup(interlaced)
+
+	// Create display and renderer
+	disp := NewDisplay(resolution, colorDepth)
+	renderer := n64draw.NewRdp()
+	renderer.SetFramebuffer(disp.Swap())
+
+	currentScreen = &screen{
+		Display:  disp,
+		Renderer: renderer,
+	}
+
+	return &Screen{
+		renderer: renderer,
+	}
+}

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,49 @@
+# N64 Basic Game Example
+
+A simple example showing how to create a game using the N64 console package. The screen cycles through red, green, and blue colors every 60 frames.
+
+## Code Structure
+
+```go
+// Game implements the console.Gamelooper interface
+type Game struct {}
+
+// Update is called every frame to update game logic
+func (g *Game) Update() error {
+    return nil
+}
+
+// Draw is called every frame to render the game
+func (g *Game) Draw(screen *display.Screen) {}
+
+func main() {
+    game := &Game{}
+    if err := console.Run(game); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+## How to Run
+
+```bash
+emgo build
+```
+
+## Key Points
+
+1. The `console.Gamelooper` interface requires two methods:
+   - `Update()`: Called every frame for game logic
+   - `Draw(screen *display.Screen)`: Called every frame for rendering
+
+2. The `console.Run()` function handles:
+   - Display initialization using a default video preset (NTSC@240p)
+   - Game loop
+
+3. Colors are provided by standard library `golang.org/x/image/colornames`:
+
+   ```go
+   colornames.Red
+   colornames.Blue
+   colornames.Green
+   ```

--- a/examples/basic/build.cfg
+++ b/examples/basic/build.cfg
@@ -1,0 +1,6 @@
+GOTARGET = n64
+GOMEM = 0x00000000:8M
+GOTEXT = 0x00000400:8M
+GOSTRIPFN = 1
+#ISRNAMES = "github.com/clktmr/n64/hal/irq"
+GOOUT = z64

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"image/color"
+
+	"golang.org/x/image/colornames"
+
+	"github.com/clktmr/n64/console"
+	"github.com/clktmr/n64/drivers/display"
+)
+
+// Game implements the console.Gamelooper interface
+type Game struct {
+	// Add your game state here
+	frameCount  int
+	screencolor color.RGBA
+}
+
+// Update your game logic here
+func (g *Game) Update() error {
+	g.frameCount++
+
+	switch (g.frameCount / 60) % 3 {
+	case 0:
+		g.screencolor = colornames.Red
+	case 1:
+		g.screencolor = colornames.Blue
+	case 2:
+		g.screencolor = colornames.Green
+	}
+
+	return nil
+}
+
+// Draw your game here
+func (g *Game) Draw(screen *display.Screen) {
+	screen.ClearBackground(g.screencolor)
+}
+
+func main() {
+	// Initialize the game
+	game := &Game{}
+
+	// Run the game in the console
+	if err := console.Run(game); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
This pull request:

1. Introduces a  video presets (lowRes and HighRes) while using by default the lowRes one (240p@NTSC). 
2. Aligns the framework with common game development patterns by standardizing the use of `Update()` and `Draw()` functions, similar to most Go developers are familiar with (from https://ebitengine.org/). 

The goal of this approach is to minimize boilerplate for initialization and basic drawing, allowing developers to focus more on gameplay logic.

Below is an example demonstrating the minimal implementation required to produce a functional z64 ROM:

```go
package main

import (
	"github.com/clktmr/n64/console"
	"github.com/clktmr/n64/drivers/display"
)

type Game struct {}

func (g *Game) Update() error {return nil}

func (g *Game) Draw(screen *display.Screen) {}

func main() {
	game := &Game{}
	if err := console.Run(game); err != nil {
		panic(err)
	}
}
```

Let me know what you think. Feel free to make suggestions if you like or completely disregard this PR if it doesn't follow your mindset about how you see things done with this library.